### PR TITLE
Schriibfähler korrigiere

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Spicke duesch grundsätzläch so:
     brew tap gexclaude/homebrew-tap
     brew install aareguru
 
-Aktualisierige duesch so
+Aktualisiere duesch so
 
     brew upgrade aareguru
 


### PR DESCRIPTION
Es git ja ke offizielli Bärndütschi Schribwiis. Aber me sött sech zmingscht chönne entscheide, ob me itze es Wort aus Verb oder aus Nomen bruucht.

Gschribe heit dr:

    Aktualisierige duesch so

An akzeptierbari Variante wäre:

    Aktualisiere duesch so # Verb
    Aktualisierige machsch so # Nomen

Aber de Hafechääse wo dert schteit, geit eifach nid.
     